### PR TITLE
Add three-column blog layout

### DIFF
--- a/content/stylesheet.css
+++ b/content/stylesheet.css
@@ -1,101 +1,92 @@
 * {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
-
-  font-family: Georgia, Palatino, serif;
 }
 
 body {
-  background: #fff;
-}
-
-a {
-  text-decoration: none;
-}
-
-a:link,
-a:visited {
-  color: #f30;
-}
-
-a:hover {
-  color: #f90;
-}
-
-#main {
-  position: absolute;
-
-  top: 40px;
-  left: 280px;
-
-  width: 500px;
-}
-
-#main h1 {
-  font-size: 40px;
-  font-weight: normal;
-
-  line-height: 40px;
-
-  letter-spacing: -1px;
-}
-
-#main p {
-  margin: 20px 0;
-
-  font-size: 15px;
-
-  line-height: 20px;
-}
-
-#main ul, #main ol {
-  margin: 20px;
-}
-
-#main li {
-  font-size: 15px;
-
-  line-height: 20px;
-}
-
-#main ul li {
-  list-style-type: square;
-}
-
-#sidebar {
-  position: absolute;
-
-  top: 40px;
-  left: 20px;
-  width: 200px;
-
-  padding: 20px 20px 0 0;
-
-  border-right: 1px solid #ccc;
-
-  text-align: right;
-}
-
-#sidebar h2 {
-  text-transform: uppercase;
-
-  font-size: 13px;
-
+  font-family: system-ui, sans-serif;
+  line-height: 1.6;
   color: #333;
-
-  letter-spacing: 1px;
-
-  line-height: 20px;
+  background: #fdfdfd;
 }
 
-#sidebar ul {
-  list-style-type: none;
-
-  margin: 20px 0;
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'DM Sans', sans-serif;
+  font-weight: 800;
 }
 
-#sidebar li {
-  font-size: 14px;
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 200px 1fr 240px;
+  grid-gap: 2rem;
+  padding: 1rem;
+}
 
-  line-height: 20px;
+header {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #e5e5e5;
+  padding-bottom: 1rem;
+}
+
+header h1 {
+  font-size: 2rem;
+}
+
+nav.sidebar-left ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+nav.sidebar-left li {
+  margin-bottom: 0.5rem;
+}
+
+nav.sidebar-left a {
+  text-decoration: none;
+  color: #333;
+}
+
+nav.sidebar-left a:hover {
+  color: #0070f3;
+}
+
+main {
+  padding: 0 1rem;
+}
+
+main h1 {
+  margin-bottom: 1rem;
+  font-size: 1.75rem;
+}
+
+main p {
+  margin: 1rem 0;
+}
+
+main ul,
+main ol {
+  margin: 1rem 0 1rem 1.5rem;
+}
+
+aside.sidebar-right section {
+  margin-bottom: 1.5rem;
+}
+
+aside.sidebar-right h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+aside.sidebar-right ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+aside.sidebar-right li {
+  margin-bottom: 0.25rem;
 }

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -2,23 +2,58 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Whomp Club - <%= @item[:title] %></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/stylesheet.css">
     <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">
   </head>
   <body>
-    <header>
-      <h1><a href="/">Whomp Club</a></h1>
-      <nav>
+    <div class="container">
+      <header>
+        <h1><a href="/">Whomp Club</a></h1>
+      </header>
+      <nav class="sidebar-left">
         <ul>
           <% @config[:nav].each do |n| %>
             <li><a href="<%= n[:link] %>"><%= n[:title] %></a></li>
           <% end %>
         </ul>
       </nav>
-    </header>
-    <main>
-      <%= yield %>
-    </main>
+      <main>
+        <%= yield %>
+      </main>
+      <aside class="sidebar-right">
+        <section class="recent-posts">
+          <h2>Recent Posts</h2>
+          <ul>
+            <% posts = @items.select { |i| i[:kind] == 'post' }.sort_by { |i| i[:date] || Time.now }.reverse.first(5) %>
+            <% posts.each do |post| %>
+              <li><a href="<%= post.path %>"><%= post[:title] %></a></li>
+            <% end %>
+          </ul>
+        </section>
+        <section class="tags">
+          <h2>Tags</h2>
+          <ul>
+            <li>Example</li>
+            <li>Sample</li>
+          </ul>
+        </section>
+        <section class="archives">
+          <h2>Archives</h2>
+          <ul>
+            <li>January 2025</li>
+            <li>December 2024</li>
+          </ul>
+        </section>
+        <section class="search">
+          <h2>Search</h2>
+          <input type="text" placeholder="Search…" />
+        </section>
+      </aside>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restructure layout into header, left navigation, main content, and right sidebar
- use DM Sans 800 for headings, system-ui for body
- add sample sidebar content including recent posts
- redesign stylesheet with CSS grid for three-column design

## Testing
- `bundle exec nanoc check` *(fails: bundler: command not found: nanoc)*

------
https://chatgpt.com/codex/tasks/task_e_684d9a24a86483288bb82b7b1f56df73