### PR TITLE
Update blog system with dated posts

### DIFF
--- a/Rules
+++ b/Rules
@@ -1,4 +1,13 @@
 #!/usr/bin/env ruby
+require 'date'
+
+preprocess do
+  @items.each do |item|
+    if (m = item.identifier.to_s.match(%r{^/blog/(\d{4}-\d{2}-\d{2})-(.+)\.md$}))
+      item[:date] = Date.parse(m[1])
+    end
+  end
+end
 
 compile '/**/*.html' do
   filter :erb
@@ -15,6 +24,14 @@ compile '/**/*.md' do
 end
 
 compile '/**/*' do
+end
+
+route '/blog/*.{html,md}' do
+  if (m = item.identifier.to_s.match(%r{^/blog/\d{4}-\d{2}-\d{2}-(.+)\.[^.]+$}))
+    "/blog/#{m[1]}/index.html"
+  else
+    item.identifier.without_ext + '/index.html'
+  end
 end
 
 route '/**/*.{html,md}' do

--- a/content/blog/2024-01-01-hello-world.md
+++ b/content/blog/2024-01-01-hello-world.md
@@ -1,6 +1,5 @@
 ---
 title: Hello World
-date: '2024-01-01'
 kind: post
 ---
 

--- a/content/blog/2024-02-01-lorem-ipsum.md
+++ b/content/blog/2024-02-01-lorem-ipsum.md
@@ -1,0 +1,18 @@
+---
+title: Lorem Ipsum
+kind: post
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel mauris quis justo elementum gravida.
+
+Vivamus sit amet porta lacus. Nulla facilisi. Phasellus in tellus eget elit euismod vehicula.
+
+Praesent commodo, lectus et suscipit ullamcorper, arcu orci hendrerit nulla, ac sollicitudin justo libero at velit.
+
+Mauris mattis lacus sit amet dui pretium, in pulvinar elit ultrices. Maecenas vitae semper elit, at finibus elit.
+
+Curabitur varius, nisl eu fermentum congue, diam urna fermentum odio, vitae placerat ante turpis nec neque.
+
+Sed vehicula dolor a urna facilisis, vitae tincidunt purus pulvinar.
+
+Duis in nunc in tellus aliquet tincidunt ac quis orci.

--- a/content/index.html
+++ b/content/index.html
@@ -3,9 +3,17 @@ title: Blog
 ---
 
 <h1>Blog</h1>
-<ul>
 <% posts = @items.select { |i| i[:kind] == 'post' }.sort_by { |i| i[:date] || Time.now }.reverse %>
 <% posts.each do |post| %>
-  <li><a href="<%= post.path %>"><%= post[:title] %></a></li>
+  <article>
+    <h2><a href="<%= post.path %>"><%= post[:title] %></a></h2>
+    <p class="date"><%= post[:date].strftime('%B %d, %Y') %></p>
+    <% html = post.compiled_content(snapshot: :pre) %>
+    <% paragraphs = html.scan(/<p.*?<\/p>/m) %>
+    <%= paragraphs.first(6).join %>
+    <% if paragraphs.length > 6 %>
+      <p><a href="<%= post.path %>">Read more…</a></p>
+    <% end %>
+  </article>
 <% end %>
-</ul>
+


### PR DESCRIPTION
## Summary
- rename blog posts to include date prefix
- parse post date from filename
- add a second lorem ipsum post
- show excerpts on the home page
- route dated posts without the date in the URL

## Testing
- `bundle exec nanoc compile`

------
https://chatgpt.com/codex/tasks/task_e_684da0a63b2c8328a151d74e00b977e9