### PR TITLE
Add version history dropdown for items

### DIFF
--- a/Rules
+++ b/Rules
@@ -24,6 +24,14 @@ compile '/**/*.md' do
 end
 
 compile '/**/*' do
+  case item[:extension]
+  when '.md'
+    filter :kramdown
+    layout '/default.*'
+  when '.html'
+    filter :erb
+    layout '/default.*'
+  end
 end
 
 route '/blog/*.{html,md}' do
@@ -44,7 +52,11 @@ route '/**/*.{html,md}' do
 end
 
 route '/**/*' do
-  item.identifier.to_s
+  if item[:version_sha]
+    item.identifier.to_s + '/index.html'
+  else
+    item.identifier.to_s
+  end
 end
 
 layout '/**/*', :erb

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -56,7 +56,32 @@
           <input type="text" placeholder="Search…" />
         </section>
       </aside>
-      <footer class="colophon">Copyright © 2025 Phillip Ridlen</footer>
+      <footer class="colophon">
+        Copyright © 2025 Phillip Ridlen
+        <% derived_base = @item[:base_id]
+           unless derived_base
+             id = @item.identifier.without_ext.to_s.sub(/^\//, '')
+             parts = id.split('/', 2)
+             derived_base = parts.last if parts.size > 1
+           end
+        %>
+        <% history = derived_base ? version_history(derived_base) : [] %>
+        <% if history.length > 1 %>
+        <details class="version-history">
+          <summary>Previous Versions</summary>
+          <ul>
+            <% history.reverse_each do |ver| %>
+              <% next if ver.identifier == @item.identifier %>
+              <li>
+                <a href="<%= ver.path %>">
+                  <%= short_sha(ver) %> - <%= version_date_formatted(ver) %>
+                </a>
+              </li>
+            <% end %>
+          </ul>
+        </details>
+        <% end %>
+      </footer>
     </div>
   </body>
 </html>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -60,7 +60,8 @@
         Copyright © 2025 Phillip Ridlen
         <% derived_base = @item[:base_id]
            unless derived_base
-             id = @item.identifier.without_ext.to_s.sub(/^\//, '')
+             id = @item.identifier.to_s.sub(/^\//, '')
+             id = id.sub(File.extname(id), '')
              parts = id.split('/', 2)
              derived_base = parts.last if parts.size > 1
            end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,0 +1,3 @@
+require_relative 'nanoc/helpers/versioned_helpers'
+
+include VersionedHelpers

--- a/lib/nanoc/data_sources/versioned.rb
+++ b/lib/nanoc/data_sources/versioned.rb
@@ -133,7 +133,7 @@ module Nanoc
           blob_entry = commit.tree.path(file_path)
           blob = repo.lookup(blob_entry[:oid])
           blob.content
-        rescue Rugged::TreeError
+        rescue Rugged::TreeError, Rugged::OdbError
           nil
         end
       end

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -69,8 +69,9 @@ data_sources:
     layouts_root: /
     encoding: utf-8
     identifier_type: full
-  - type: versioned 
-    content_dir: content/games 
+  - type: versioned
+    content_dir: content
+    prefix: games
     items_root: /games/
     layouts_dir: null
     layouts_root: /

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,7 @@
 [build]
 command = "nanoc compile"
 publish = "output"
-environment = { RUBY_VERSION = "3.4.4", NETLIFY_USE_SHALLOW_CLONE = "false" }
+
+[build.environment]
+RUBY_VERSION = "3.4.4"
+NETLIFY_USE_SHALLOW_CLONE = "false"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
 command = "nanoc compile"
 publish = "output"
-environment = { RUBY_VERSION = "3.4.4" }
+environment = { RUBY_VERSION = "3.4.4", NETLIFY_USE_SHALLOW_CLONE = "false" }

--- a/spec/data_sources/versioned_spec.rb
+++ b/spec/data_sources/versioned_spec.rb
@@ -308,5 +308,18 @@ RSpec.describe Nanoc::DataSources::Versioned do
         expect(temp_item.attributes[:title]).to eq('Temporary')
       end
     end
+
+    context 'with missing git objects' do
+      before do
+        repo = Rugged::Repository.new('.')
+        oid = repo.head.target.tree.first[:oid]
+        object_path = File.join(repo.path, 'objects', oid[0, 2], oid[2..])
+        FileUtils.rm_f(object_path)
+      end
+
+      it 'handles Rugged::OdbError gracefully' do
+        expect { data_source.items.to_a }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- add VersionedHelpers to Nanoc via `lib/helpers.rb`
- show version history in default layout using an HTML `<details>` element
- fix versioned data source configuration
- compile and route versioned items correctly

## Testing
- `bundle install`
- `bundle exec rspec`
- `bundle exec nanoc compile`


------
https://chatgpt.com/codex/tasks/task_e_685044213d308328bbfb702a88e2e011